### PR TITLE
Rename variables

### DIFF
--- a/src/perf_event/counting/builder.rs
+++ b/src/perf_event/counting/builder.rs
@@ -11,9 +11,7 @@ impl Builder {
                 pid: Some(pid),
                 cpu: Some(cpu),
                 ..
-            } => {
-                unsafe { Counter::new(cfg, *pid, *cpu, -1, 0) }.map_err(BuildError::SyscallFailed)
-            }
+            } => unsafe { Counter::new(cfg, *pid, *cpu, -1, 0) }.map_err(BuildError::SyscallFailed),
         }
     }
 

--- a/src/perf_event/counting/tests/hw/cpu_cycles.rs
+++ b/src/perf_event/counting/tests/hw/cpu_cycles.rs
@@ -14,49 +14,49 @@ fn gen_counting() -> Counter {
 
 #[test]
 fn test_basic() {
-    let mut counting = gen_counting();
+    let mut counter = gen_counting();
 
-    let before = counting.result().unwrap().event_count;
+    let before = counter.result().unwrap().event_count;
     dbg!(before);
     assert_eq!(before, 0);
-    counting.enable().unwrap();
+    counter.enable().unwrap();
 
     cpu_workload();
 
-    counting.disable().unwrap();
-    let after = counting.result().unwrap().event_count;
+    counter.disable().unwrap();
+    let after = counter.result().unwrap().event_count;
     dbg!(after);
     assert!(after > 0);
 }
 
 #[test]
 fn test_enable_disable() {
-    let mut counting = gen_counting();
+    let mut counter = gen_counting();
 
-    counting.enable().unwrap();
+    counter.enable().unwrap();
     cpu_workload();
-    counting.disable().unwrap();
-    let after = counting.result().unwrap().event_count;
+    counter.disable().unwrap();
+    let after = counter.result().unwrap().event_count;
     assert!(after > 0);
 
-    assert_eq!(after, counting.result().unwrap().event_count);
-    counting.enable().unwrap();
+    assert_eq!(after, counter.result().unwrap().event_count);
+    counter.enable().unwrap();
     cpu_workload();
-    assert!(after < counting.result().unwrap().event_count);
+    assert!(after < counter.result().unwrap().event_count);
 }
 
 #[test]
 fn test_reset_count() {
-    let mut counting = gen_counting();
+    let mut counter = gen_counting();
 
-    counting.enable().unwrap();
+    counter.enable().unwrap();
     cpu_workload();
-    counting.disable().unwrap();
-    let count = counting.result().unwrap().event_count;
+    counter.disable().unwrap();
+    let count = counter.result().unwrap().event_count;
     assert!(count > 0);
 
-    counting.disable().unwrap();
-    counting.reset_count().unwrap();
+    counter.disable().unwrap();
+    counter.reset_count().unwrap();
     cpu_workload();
-    assert_eq!(counting.result().unwrap().event_count, 0);
+    assert_eq!(counter.result().unwrap().event_count, 0);
 }

--- a/src/perf_event/counting/tests/sw/cpu_clock.rs
+++ b/src/perf_event/counting/tests/sw/cpu_clock.rs
@@ -14,49 +14,49 @@ fn gen_counting() -> Counter {
 
 #[test]
 fn test_basic() {
-    let mut counting = gen_counting();
+    let mut counter = gen_counting();
 
-    let before = counting.result().unwrap().event_count;
+    let before = counter.result().unwrap().event_count;
     dbg!(before);
     assert_eq!(before, 0);
-    counting.enable().unwrap();
+    counter.enable().unwrap();
 
     cpu_workload();
 
-    counting.disable().unwrap();
-    let after = counting.result().unwrap().event_count;
+    counter.disable().unwrap();
+    let after = counter.result().unwrap().event_count;
     dbg!(after);
     assert!(after > 0);
 }
 
 #[test]
 fn test_enable_disable() {
-    let mut counting = gen_counting();
+    let mut counter = gen_counting();
 
-    counting.enable().unwrap();
+    counter.enable().unwrap();
     cpu_workload();
-    counting.disable().unwrap();
-    let after = counting.result().unwrap().event_count;
+    counter.disable().unwrap();
+    let after = counter.result().unwrap().event_count;
     assert!(after > 0);
 
-    assert_eq!(after, counting.result().unwrap().event_count);
-    counting.enable().unwrap();
+    assert_eq!(after, counter.result().unwrap().event_count);
+    counter.enable().unwrap();
     cpu_workload();
-    assert!(after < counting.result().unwrap().event_count);
+    assert!(after < counter.result().unwrap().event_count);
 }
 
 #[test]
 fn test_reset_count() {
-    let mut counting = gen_counting();
+    let mut counter = gen_counting();
 
-    counting.enable().unwrap();
+    counter.enable().unwrap();
     cpu_workload();
-    counting.disable().unwrap();
-    let count = counting.result().unwrap().event_count;
+    counter.disable().unwrap();
+    let count = counter.result().unwrap().event_count;
     assert!(count > 0);
 
-    counting.disable().unwrap();
-    counting.reset_count().unwrap();
+    counter.disable().unwrap();
+    counter.reset_count().unwrap();
     cpu_workload();
-    assert_eq!(counting.result().unwrap().event_count, 0);
+    assert_eq!(counter.result().unwrap().event_count, 0);
 }

--- a/src/perf_event/event/tracing/dynamic_pmu.rs
+++ b/src/perf_event/event/tracing/dynamic_pmu.rs
@@ -18,7 +18,7 @@ pub struct UprobeConfig {
 
 #[derive(Clone, Debug)]
 pub enum DynamicPmuEvent {
-    Other{
+    Other {
         /// The content of `/sys/bus/event_source/devices/*/type`
         r#type: u32,
         /// See: `/sys/bus/event_source/devices/*/format/*`

--- a/src/perf_event/sampling/tests/hw/cpu_cycles.rs
+++ b/src/perf_event/sampling/tests/hw/cpu_cycles.rs
@@ -23,15 +23,15 @@ fn gen_cfg() -> Config {
 fn test_basic() {
     let builder = gen_builder(1 + (1 << 16));
     let cfg = gen_cfg();
-    let sampling = builder.build_sampling(&cfg).unwrap();
+    let mut sampler = builder.build_sampling(&cfg).unwrap();
 
-    sampling.enable().unwrap();
+    sampler.enable().unwrap();
     cpu_workload();
-    sampling.disable().unwrap();
+    sampler.disable().unwrap();
 
     let mut sample_count = 0_usize;
     let mut last_time = 0;
-    for Record { body, .. } in sampling {
+    for Record { body, .. } in sampler.iter() {
         if let RecordBody::Sample(sample) = body {
             assert!(sample.time.unwrap() >= last_time);
             last_time = sample.time.unwrap();
@@ -45,15 +45,15 @@ fn test_basic() {
 fn test_all_records() {
     let builder = gen_builder(1 + (1 << 16));
     let cfg = gen_cfg();
-    let sampling = builder.build_sampling(&cfg).unwrap();
+    let mut sampler = builder.build_sampling(&cfg).unwrap();
 
-    sampling.enable().unwrap();
+    sampler.enable().unwrap();
     cpu_workload();
-    sampling.disable().unwrap();
+    sampler.disable().unwrap();
 
     let mut sample_count = 0_usize;
     let mut last_time = 0;
-    for Record { body, .. } in sampling {
+    for Record { body, .. } in sampler.iter() {
         if let RecordBody::Sample(sample) = body {
             assert!(sample.time.unwrap() >= last_time);
             last_time = sample.time.unwrap();
@@ -67,67 +67,67 @@ fn test_all_records() {
 fn test_enable_disable() {
     let builder = gen_builder(1 + (1 << 16));
     let cfg = gen_cfg();
-    let mut sampling = builder.build_sampling(&cfg).unwrap();
+    let mut sampler = builder.build_sampling(&cfg).unwrap();
 
-    assert!(sampling.next_record().is_none());
-    sampling.enable().unwrap();
+    assert!(sampler.next_record().is_none());
+    sampler.enable().unwrap();
     cpu_workload();
-    sampling.disable().unwrap();
+    sampler.disable().unwrap();
 
     {
         let mut sample_count = 0_usize;
-        for _ in sampling.iter() {
+        for _ in sampler.iter() {
             sample_count += 1;
         }
         assert!(sample_count > 0);
     }
 
     cpu_workload();
-    assert!(sampling.next_record().is_none());
+    assert!(sampler.next_record().is_none());
 
-    sampling.enable().unwrap();
+    sampler.enable().unwrap();
     cpu_workload();
-    assert!(sampling.next_record().is_some());
+    assert!(sampler.next_record().is_some());
 }
 
 #[test]
 fn test_pause_resume() {
     let builder = gen_builder(1 + (1 << 16));
     let cfg = gen_cfg();
-    let mut sampling = builder.build_sampling(&cfg).unwrap();
+    let mut sampler = builder.build_sampling(&cfg).unwrap();
 
-    assert!(sampling.next_record().is_none());
-    sampling.enable().unwrap();
+    assert!(sampler.next_record().is_none());
+    sampler.enable().unwrap();
     cpu_workload();
-    sampling.pause().unwrap();
+    sampler.pause().unwrap();
 
     {
         let mut sample_count = 0_usize;
-        for _ in sampling.iter() {
+        for _ in sampler.iter() {
             sample_count += 1;
         }
         assert!(sample_count > 0);
     }
 
     cpu_workload();
-    assert!(sampling.next_record().is_none());
+    assert!(sampler.next_record().is_none());
 
-    sampling.resume().unwrap();
+    sampler.resume().unwrap();
     cpu_workload();
-    assert!(sampling.next_record().is_some());
+    assert!(sampler.next_record().is_some());
 }
 
 #[test]
 fn test_ring_buffer() {
     let builder = gen_builder(1 + 512);
     let cfg = gen_cfg();
-    let mut sampling = builder.build_sampling(&cfg).unwrap();
+    let mut sampler = builder.build_sampling(&cfg).unwrap();
 
-    sampling.enable().unwrap();
+    sampler.enable().unwrap();
     cpu_workload();
 
     let mut sample_count = 0_usize;
-    for Record { body, .. } in sampling.iter() {
+    for Record { body, .. } in sampler.iter() {
         if let RecordBody::Sample(_) = body {
             sample_count += 1;
         }

--- a/src/perf_event/sampling/tests/hw/sample_record_fields/abi_and_regs_intr.rs
+++ b/src/perf_event/sampling/tests/hw/sample_record_fields/abi_and_regs_intr.rs
@@ -26,14 +26,14 @@ fn test() {
     let builder = gen_builder();
     for i in 1..7 {
         let cfg = gen_cfg(i);
-        let sampling = builder.build_sampling(&cfg).unwrap();
+        let mut sampler = builder.build_sampling(&cfg).unwrap();
 
-        sampling.enable().unwrap();
+        sampler.enable().unwrap();
         cpu_workload();
-        sampling.disable().unwrap();
+        sampler.disable().unwrap();
 
         let mut sample_count = 0_usize;
-        for Record { body, .. } in sampling {
+        for Record { body, .. } in sampler.iter() {
             if let RecordBody::Sample(body) = body {
                 assert!(body.abi_and_regs_intr.is_some());
                 sample_count += 1;

--- a/src/perf_event/sampling/tests/hw/sample_record_fields/abi_and_regs_user.rs
+++ b/src/perf_event/sampling/tests/hw/sample_record_fields/abi_and_regs_user.rs
@@ -26,14 +26,14 @@ fn test() {
     let builder = gen_builder();
     for i in 1..7 {
         let cfg = gen_cfg(i);
-        let sampling = builder.build_sampling(&cfg).unwrap();
+        let mut sampler = builder.build_sampling(&cfg).unwrap();
 
-        sampling.enable().unwrap();
+        sampler.enable().unwrap();
         cpu_workload();
-        sampling.disable().unwrap();
+        sampler.disable().unwrap();
 
         let mut sample_count = 0_usize;
-        for Record { body, .. } in sampling {
+        for Record { body, .. } in sampler.iter() {
             if let RecordBody::Sample(body) = body {
                 assert!(body.abi_and_regs_user.is_some());
                 sample_count += 1;

--- a/src/perf_event/sampling/tests/hw/sample_record_fields/all.rs
+++ b/src/perf_event/sampling/tests/hw/sample_record_fields/all.rs
@@ -49,13 +49,13 @@ fn test() {
     let builder = gen_builder();
     let cfg = gen_cfg(extra_config);
 
-    let sampling = builder.build_sampling(&cfg).unwrap();
-    sampling.enable().unwrap();
+    let mut sampler = builder.build_sampling(&cfg).unwrap();
+    sampler.enable().unwrap();
     cpu_workload();
-    sampling.disable().unwrap();
+    sampler.disable().unwrap();
 
     let mut sample_count = 0_usize;
-    for Record { body, .. } in sampling {
+    for Record { body, .. } in sampler.iter() {
         if let RecordBody::Sample(body) = body {
             assert!(body.sample_id.is_some());
             assert!(body.ip.is_some());

--- a/src/perf_event/sampling/tests/hw/sample_record_fields/data_stack_user.rs
+++ b/src/perf_event/sampling/tests/hw/sample_record_fields/data_stack_user.rs
@@ -26,14 +26,14 @@ fn test() {
     let builder = gen_builder();
     for i in 3..8 {
         let cfg = gen_cfg(2_u16.pow(i));
-        let sampling = builder.build_sampling(&cfg).unwrap();
+        let mut sampler = builder.build_sampling(&cfg).unwrap();
 
-        sampling.enable().unwrap();
+        sampler.enable().unwrap();
         cpu_workload();
-        sampling.disable().unwrap();
+        sampler.disable().unwrap();
 
         let mut sample_count = 0_usize;
-        for Record { body, .. } in sampling {
+        for Record { body, .. } in sampler.iter() {
             if let RecordBody::Sample(body) = body {
                 assert!(body.data_stack_user.is_some());
                 sample_count += 1;

--- a/src/perf_event/sampling/tests/hw/sample_record_fields/ips.rs
+++ b/src/perf_event/sampling/tests/hw/sample_record_fields/ips.rs
@@ -26,14 +26,14 @@ fn test() {
     let builder = gen_builder();
     for i in 1..7 {
         let cfg = gen_cfg(i);
-        let sampling = builder.build_sampling(&cfg).unwrap();
+        let mut sampler = builder.build_sampling(&cfg).unwrap();
 
-        sampling.enable().unwrap();
+        sampler.enable().unwrap();
         cpu_workload();
-        sampling.disable().unwrap();
+        sampler.disable().unwrap();
 
         let mut sample_count = 0_usize;
-        for Record { body, .. } in sampling {
+        for Record { body, .. } in sampler.iter() {
             if let RecordBody::Sample(body) = body {
                 assert!(body.ips.is_some());
                 sample_count += 1;

--- a/src/perf_event/sampling/tests/hw/sample_record_fields/mod.rs
+++ b/src/perf_event/sampling/tests/hw/sample_record_fields/mod.rs
@@ -35,13 +35,13 @@ macro_rules! gen_test {
             let builder = gen_builder();
             let cfg = gen_cfg(extra_config);
 
-            let sampling = builder.build_sampling(&cfg).unwrap();
-            sampling.enable().unwrap();
+            let mut sampler = builder.build_sampling(&cfg).unwrap();
+            sampler.enable().unwrap();
             cpu_workload();
-            sampling.disable().unwrap();
+            sampler.disable().unwrap();
 
             let mut sample_count = 0_usize;
-            for Record { body, .. } in sampling {
+            for Record { body, .. } in sampler.iter() {
                 if let RecordBody::Sample(body) = body {
                     assert!(body.$field.is_some());
                     sample_count += 1;
@@ -63,13 +63,13 @@ fn pid_and_tid() {
     let builder = gen_builder();
     let cfg = gen_cfg(extra_config);
 
-    let sampling = builder.build_sampling(&cfg).unwrap();
-    sampling.enable().unwrap();
+    let mut sampler = builder.build_sampling(&cfg).unwrap();
+    sampler.enable().unwrap();
     cpu_workload();
-    sampling.disable().unwrap();
+    sampler.disable().unwrap();
 
     let mut sample_count = 0_usize;
-    for Record { body, .. } in sampling {
+    for Record { body, .. } in sampler.iter() {
         if let RecordBody::Sample(body) = body {
             assert!(body.pid.is_some());
             assert!(body.tid.is_some());

--- a/src/perf_event/sampling/tests/hw/sample_record_fields/weight.rs
+++ b/src/perf_event/sampling/tests/hw/sample_record_fields/weight.rs
@@ -26,14 +26,14 @@ fn gen_cfg(repr: WeightRepr) -> Config {
 fn test_full() {
     let builder = gen_builder();
     let cfg = gen_cfg(WeightRepr::Full);
-    let sampling = builder.build_sampling(&cfg).unwrap();
+    let mut sampler = builder.build_sampling(&cfg).unwrap();
 
-    sampling.enable().unwrap();
+    sampler.enable().unwrap();
     cpu_workload();
-    sampling.disable().unwrap();
+    sampler.disable().unwrap();
 
     let mut sample_count = 0_usize;
-    for Record { body, .. } in sampling {
+    for Record { body, .. } in sampler.iter() {
         if let RecordBody::Sample(body) = body {
             assert!(matches!(body.weight, Some(Weight::Full(_))));
             sample_count += 1;
@@ -46,14 +46,14 @@ fn test_full() {
 fn test_vars() {
     let builder = gen_builder();
     let cfg = gen_cfg(WeightRepr::Vars);
-    let sampling = builder.build_sampling(&cfg).unwrap();
+    let mut sampler = builder.build_sampling(&cfg).unwrap();
 
-    sampling.enable().unwrap();
+    sampler.enable().unwrap();
     cpu_workload();
-    sampling.disable().unwrap();
+    sampler.disable().unwrap();
 
     let mut sample_count = 0_usize;
-    for Record { body, .. } in sampling {
+    for Record { body, .. } in sampler.iter() {
         if let RecordBody::Sample(body) = body {
             assert!(matches!(body.weight, Some(Weight::Vars { .. })));
             sample_count += 1;

--- a/src/perf_event/sampling/tests/sw/cpu_clock.rs
+++ b/src/perf_event/sampling/tests/sw/cpu_clock.rs
@@ -23,15 +23,15 @@ fn gen_cfg() -> Config {
 fn test_basic() {
     let builder = gen_builder(1 + (1 << 16));
     let cfg = gen_cfg();
-    let sampling = builder.build_sampling(&cfg).unwrap();
+    let mut sampler = builder.build_sampling(&cfg).unwrap();
 
-    sampling.enable().unwrap();
+    sampler.enable().unwrap();
     cpu_workload();
-    sampling.disable().unwrap();
+    sampler.disable().unwrap();
 
     let mut sample_count = 0_usize;
     let mut last_time = 0;
-    for Record { body, .. } in sampling {
+    for Record { body, .. } in sampler.iter() {
         if let RecordBody::Sample(sample) = body {
             assert!(sample.time.unwrap() >= last_time);
             last_time = sample.time.unwrap();
@@ -45,15 +45,15 @@ fn test_basic() {
 fn test_all_records() {
     let builder = gen_builder(1 + (1 << 16));
     let cfg = gen_cfg();
-    let sampling = builder.build_sampling(&cfg).unwrap();
+    let mut sampler = builder.build_sampling(&cfg).unwrap();
 
-    sampling.enable().unwrap();
+    sampler.enable().unwrap();
     cpu_workload();
-    sampling.disable().unwrap();
+    sampler.disable().unwrap();
 
     let mut sample_count = 0_usize;
     let mut last_time = 0;
-    for Record { body, .. } in sampling {
+    for Record { body, .. } in sampler.iter() {
         if let RecordBody::Sample(sample) = body {
             assert!(sample.time.unwrap() >= last_time);
             last_time = sample.time.unwrap();
@@ -67,67 +67,67 @@ fn test_all_records() {
 fn test_enable_disable() {
     let builder = gen_builder(1 + (1 << 16));
     let cfg = gen_cfg();
-    let mut sampling = builder.build_sampling(&cfg).unwrap();
+    let mut sampler = builder.build_sampling(&cfg).unwrap();
 
-    assert!(sampling.next_record().is_none());
-    sampling.enable().unwrap();
+    assert!(sampler.next_record().is_none());
+    sampler.enable().unwrap();
     cpu_workload();
-    sampling.disable().unwrap();
+    sampler.disable().unwrap();
 
     {
         let mut sample_count = 0_usize;
-        for _ in sampling.iter() {
+        for _ in sampler.iter() {
             sample_count += 1;
         }
         assert!(sample_count > 0);
     }
 
     cpu_workload();
-    assert!(sampling.next_record().is_none());
+    assert!(sampler.next_record().is_none());
 
-    sampling.enable().unwrap();
+    sampler.enable().unwrap();
     cpu_workload();
-    assert!(sampling.next_record().is_some());
+    assert!(sampler.next_record().is_some());
 }
 
 #[test]
 fn test_pause_resume() {
     let builder = gen_builder(1 + (1 << 16));
     let cfg = gen_cfg();
-    let mut sampling = builder.build_sampling(&cfg).unwrap();
+    let mut sampler = builder.build_sampling(&cfg).unwrap();
 
-    assert!(sampling.next_record().is_none());
-    sampling.enable().unwrap();
+    assert!(sampler.next_record().is_none());
+    sampler.enable().unwrap();
     cpu_workload();
-    sampling.pause().unwrap();
+    sampler.pause().unwrap();
 
     {
         let mut sample_count = 0_usize;
-        for _ in sampling.iter() {
+        for _ in sampler.iter() {
             sample_count += 1;
         }
         assert!(sample_count > 0);
     }
 
     cpu_workload();
-    assert!(sampling.next_record().is_none());
+    assert!(sampler.next_record().is_none());
 
-    sampling.resume().unwrap();
+    sampler.resume().unwrap();
     cpu_workload();
-    assert!(sampling.next_record().is_some());
+    assert!(sampler.next_record().is_some());
 }
 
 #[test]
 fn test_ring_buffer() {
     let builder = gen_builder(1 + (1 << 16));
     let cfg = gen_cfg();
-    let mut sampling = builder.build_sampling(&cfg).unwrap();
+    let mut sampler = builder.build_sampling(&cfg).unwrap();
 
-    sampling.enable().unwrap();
+    sampler.enable().unwrap();
     cpu_workload();
 
     let mut sample_count = 0_usize;
-    for Record { body, .. } in sampling.iter() {
+    for Record { body, .. } in sampler.iter() {
         if let RecordBody::Sample(_) = body {
             sample_count += 1;
         }

--- a/src/perf_event/sampling/tests/sw/sample_record_fields/abi_and_regs_intr.rs
+++ b/src/perf_event/sampling/tests/sw/sample_record_fields/abi_and_regs_intr.rs
@@ -27,15 +27,15 @@ fn test() {
     let builder = gen_builder();
     for i in 1..7 {
         let cfg = gen_cfg(i);
-        let sampling = builder.build_sampling(&cfg).unwrap();
+        let mut sampler = builder.build_sampling(&cfg).unwrap();
 
-        sampling.enable().unwrap();
+        sampler.enable().unwrap();
         cpu_workload();
-        sampling.disable().unwrap();
+        sampler.disable().unwrap();
 
         let mut sample_count = 0_usize;
         let mut last_time = 0;
-        for Record { body, .. } in sampling {
+        for Record { body, .. } in sampler.iter() {
             if let RecordBody::Sample(sample) = body {
                 assert!(sample.time.unwrap() >= last_time);
                 last_time = sample.time.unwrap();

--- a/src/perf_event/sampling/tests/sw/sample_record_fields/abi_and_regs_user.rs
+++ b/src/perf_event/sampling/tests/sw/sample_record_fields/abi_and_regs_user.rs
@@ -27,15 +27,15 @@ fn test() {
     let builder = gen_builder();
     for i in 1..7 {
         let cfg = gen_cfg(i);
-        let sampling = builder.build_sampling(&cfg).unwrap();
+        let mut sampler = builder.build_sampling(&cfg).unwrap();
 
-        sampling.enable().unwrap();
+        sampler.enable().unwrap();
         cpu_workload();
-        sampling.disable().unwrap();
+        sampler.disable().unwrap();
 
         let mut sample_count = 0_usize;
         let mut last_time = 0;
-        for Record { body, .. } in sampling {
+        for Record { body, .. } in sampler.iter() {
             if let RecordBody::Sample(sample) = body {
                 assert!(sample.time.unwrap() >= last_time);
                 last_time = sample.time.unwrap();

--- a/src/perf_event/sampling/tests/sw/sample_record_fields/all.rs
+++ b/src/perf_event/sampling/tests/sw/sample_record_fields/all.rs
@@ -49,13 +49,13 @@ fn test() {
     let builder = gen_builder();
     let cfg = gen_cfg(extra_config);
 
-    let sampling = builder.build_sampling(&cfg).unwrap();
-    sampling.enable().unwrap();
+    let mut sampler = builder.build_sampling(&cfg).unwrap();
+    sampler.enable().unwrap();
     cpu_workload();
-    sampling.disable().unwrap();
+    sampler.disable().unwrap();
 
     let mut sample_count = 0_usize;
-    for Record { body, .. } in sampling {
+    for Record { body, .. } in sampler.iter() {
         if let RecordBody::Sample(body) = body {
             assert!(body.sample_id.is_some());
             assert!(body.ip.is_some());

--- a/src/perf_event/sampling/tests/sw/sample_record_fields/data_stack_user.rs
+++ b/src/perf_event/sampling/tests/sw/sample_record_fields/data_stack_user.rs
@@ -27,15 +27,15 @@ fn test() {
     let builder = gen_builder();
     for i in 3..8 {
         let cfg = gen_cfg(2_u16.pow(i));
-        let sampling = builder.build_sampling(&cfg).unwrap();
+        let mut sampler = builder.build_sampling(&cfg).unwrap();
 
-        sampling.enable().unwrap();
+        sampler.enable().unwrap();
         cpu_workload();
-        sampling.disable().unwrap();
+        sampler.disable().unwrap();
 
         let mut sample_count = 0_usize;
         let mut last_time = 0;
-        for Record { body, .. } in sampling {
+        for Record { body, .. } in sampler.iter() {
             if let RecordBody::Sample(sample) = body {
                 assert!(sample.time.unwrap() >= last_time);
                 last_time = sample.time.unwrap();

--- a/src/perf_event/sampling/tests/sw/sample_record_fields/ips.rs
+++ b/src/perf_event/sampling/tests/sw/sample_record_fields/ips.rs
@@ -27,15 +27,15 @@ fn test() {
     let builder = gen_builder();
     for i in 1..7 {
         let cfg = gen_cfg(i);
-        let sampling = builder.build_sampling(&cfg).unwrap();
+        let mut sampler = builder.build_sampling(&cfg).unwrap();
 
-        sampling.enable().unwrap();
+        sampler.enable().unwrap();
         cpu_workload();
-        sampling.disable().unwrap();
+        sampler.disable().unwrap();
 
         let mut sample_count = 0_usize;
         let mut last_time = 0;
-        for Record { body, .. } in sampling {
+        for Record { body, .. } in sampler.iter() {
             if let RecordBody::Sample(sample) = body {
                 assert!(sample.time.unwrap() >= last_time);
                 last_time = sample.time.unwrap();

--- a/src/perf_event/sampling/tests/sw/sample_record_fields/weight.rs
+++ b/src/perf_event/sampling/tests/sw/sample_record_fields/weight.rs
@@ -26,14 +26,14 @@ fn gen_cfg(repr: WeightRepr) -> Config {
 fn test_full() {
     let builder = gen_builder();
     let cfg = gen_cfg(WeightRepr::Full);
-    let sampling = builder.build_sampling(&cfg).unwrap();
+    let mut sampler = builder.build_sampling(&cfg).unwrap();
 
-    sampling.enable().unwrap();
+    sampler.enable().unwrap();
     cpu_workload();
-    sampling.disable().unwrap();
+    sampler.disable().unwrap();
 
     let mut sample_count = 0_usize;
-    for Record { body, .. } in sampling {
+    for Record { body, .. } in sampler.iter() {
         if let RecordBody::Sample(body) = body {
             assert!(matches!(body.weight, Some(Weight::Full(_))));
             sample_count += 1;
@@ -46,14 +46,14 @@ fn test_full() {
 fn test_vars() {
     let builder = gen_builder();
     let cfg = gen_cfg(WeightRepr::Vars);
-    let sampling = builder.build_sampling(&cfg).unwrap();
+    let mut sampler = builder.build_sampling(&cfg).unwrap();
 
-    sampling.enable().unwrap();
+    sampler.enable().unwrap();
     cpu_workload();
-    sampling.disable().unwrap();
+    sampler.disable().unwrap();
 
     let mut sample_count = 0_usize;
-    for Record { body, .. } in sampling {
+    for Record { body, .. } in sampler.iter() {
         if let RecordBody::Sample(body) = body {
             assert!(matches!(body.weight, Some(Weight::Vars { .. })));
             sample_count += 1;

--- a/src/perf_event/tracing/tests/breakpoint.rs
+++ b/src/perf_event/tracing/tests/breakpoint.rs
@@ -30,17 +30,17 @@ fn test_basic() {
         }
     };
     let cfg = gen_cfg(bp_type);
-    let tracing = builder.build_tracing(&cfg).unwrap();
+    let mut tracer = builder.build_tracing(&cfg).unwrap();
 
-    tracing.enable().unwrap();
+    tracer.enable().unwrap();
     for i in 0..114514 {
         a = i;
         std::hint::black_box(a);
     }
-    tracing.disable().unwrap();
+    tracer.disable().unwrap();
 
     let mut sample_count = 0;
-    for Record { body, .. } in tracing {
+    for Record { body, .. } in tracer.iter() {
         if let RecordBody::Sample(body) = body {
             sample_count += 1;
             assert_eq!(body.addr.unwrap(), a_addr);

--- a/src/perf_event/tracing/tests/tracepoint.rs
+++ b/src/perf_event/tracing/tests/tracepoint.rs
@@ -31,14 +31,14 @@ fn test_basic() {
         u64::from_str(string.as_str()).unwrap()
     };
     let cfg = gen_cfg(id);
-    let tracing = builder.build_tracing(&cfg).unwrap();
+    let mut tracer = builder.build_tracing(&cfg).unwrap();
 
-    tracing.enable().unwrap();
+    tracer.enable().unwrap();
     cpu_workload();
-    tracing.disable().unwrap();
+    tracer.disable().unwrap();
 
     let mut sample_count = 0;
-    for Record { body, .. } in tracing {
+    for Record { body, .. } in tracer.iter() {
         if let RecordBody::Sample(body) = body {
             sample_count += 1;
             assert!(body.data_raw.is_some());


### PR DESCRIPTION
Since structs like `Counting` have been renamed to `Counter`, it's better to rename the variables of these structs for better coding style.