### PR TITLE
Move `update_period` from `Counter` to `Sampler`

### DIFF
--- a/src/perf_event/counting/single.rs
+++ b/src/perf_event/counting/single.rs
@@ -73,14 +73,6 @@ impl Counter {
         ioctl_wrapped::<()>(&self.file, syscall::bindings::PERF_EVENT_IOCTL_RESET, None)
     }
 
-    pub fn update_period(&self, new: u64) -> io::Result<()> {
-        ioctl_wrapped(
-            &self.file,
-            syscall::bindings::PERF_EVENT_IOCTL_PERIOD,
-            Some(&new),
-        )
-    }
-
     pub fn set_output(&self, new: &File) -> io::Result<()> {
         let raw_fd = new.as_raw_fd() as i64;
         ioctl_wrapped(

--- a/src/perf_event/sampling/single/mod.rs
+++ b/src/perf_event/sampling/single/mod.rs
@@ -104,6 +104,10 @@ impl Sampler {
         ioctl_wrapped(&self.file, PERF_EVENT_IOCTL_REFRESH, Some(refresh))
     }
 
+    pub fn update_period(&self, new: u64) -> io::Result<()> {
+        ioctl_wrapped(&self.file, PERF_EVENT_IOCTL_PERIOD, Some(&new))
+    }
+
     pub fn next_record(&mut self) -> Option<Record> {
         next_record(self)
     }


### PR DESCRIPTION
The `update_period` function updates the event overflow period only for sampling mode, not for counting mode.