### PR TITLE
Wrap rust-bindgen generated struct `perf_event_attr` to `PerfEventAttr`

### DIFF
--- a/src/perf_event/counting/config/mod.rs
+++ b/src/perf_event/counting/config/mod.rs
@@ -1,7 +1,7 @@
 mod extra_config;
 mod new;
 
-use crate::perf_event::RawAttr;
+use crate::perf_event::PerfEventAttr;
 use std::ffi::CString;
 use std::fmt::Debug;
 use std::rc::Rc;
@@ -14,7 +14,7 @@ pub struct Config {
     // This will keep the ptr of `kprobe_func` or `uprobe_path` valid if present.
     #[allow(dead_code)]
     kprobe_func_or_uprobe_path: Option<Rc<CString>>,
-    raw_attr: RawAttr,
+    perf_event_attr: PerfEventAttr,
 }
 
 impl Config {
@@ -30,22 +30,26 @@ impl Config {
         new::new(event, scopes, extra_config)
     }
 
-    /// Construct from a raw `perf_event_attr` struct.
+    /// Construct from a `PerfEventAttr` struct.
     /// # Safety
-    /// The `raw_attr` argument must be a properly initialized
-    /// `perf_event_attr` struct for counting mode.
-    pub const unsafe fn from_raw(raw_attr: RawAttr) -> Self {
+    /// The `perf_event_attr` argument must be properly initialized from
+    /// `PerfEventAttr` struct for counting mode.
+    pub const unsafe fn from_raw(perf_event_attr: PerfEventAttr) -> Self {
         Self {
             kprobe_func_or_uprobe_path: None,
-            raw_attr,
+            perf_event_attr,
         }
     }
 
-    pub fn into_raw(self) -> RawAttr {
-        self.raw_attr
+    pub fn into_raw(self) -> PerfEventAttr {
+        self.perf_event_attr
     }
 
-    pub const fn as_raw(&self) -> &RawAttr {
-        &self.raw_attr
+    pub const fn as_raw(&self) -> &PerfEventAttr {
+        &self.perf_event_attr
+    }
+
+    pub fn as_mut_raw(&mut self) -> &mut PerfEventAttr {
+        &mut self.perf_event_attr
     }
 }

--- a/src/perf_event/counting/config/new.rs
+++ b/src/perf_event/counting/config/new.rs
@@ -1,9 +1,9 @@
 use crate::counting::{Config, ExtraConfig};
-use crate::perf_event::RawAttr;
+use crate::perf_event::PerfEventAttr;
 use crate::syscall::bindings::*;
 #[cfg(feature = "linux-4.17")]
 use crate::{DynamicPmuEvent, KprobeConfig, UprobeConfig};
-use crate::{Event, EventScope};
+use crate::{Event, EventScope, RawPerfEventAttr};
 use std::mem::size_of;
 
 #[inline]
@@ -12,9 +12,9 @@ pub fn new<'t>(
     scopes: impl IntoIterator<Item = &'t EventScope>,
     extra_config: &ExtraConfig,
 ) -> Config {
-    let mut raw_attr = RawAttr {
+    let mut perf_event_attr = PerfEventAttr(RawPerfEventAttr {
         type_: 0,
-        size: size_of::<RawAttr>() as _,
+        size: size_of::<RawPerfEventAttr>() as _,
         config: 0,
         // not use in counting mode
         __bindgen_anon_1: perf_event_attr__bindgen_ty_1::default(),
@@ -29,7 +29,7 @@ pub fn new<'t>(
             val as _
         },
         _bitfield_align_1: [],
-        // set later via raw_attr.set_...
+        // set later via perf_event_attr.set_...
         _bitfield_1: __BindgenBitfieldUnit::new([0u8; 8usize]),
         __bindgen_anon_2: perf_event_attr__bindgen_ty_2::default(), // not use in counting mode
 
@@ -60,76 +60,76 @@ pub fn new<'t>(
         // TODO: https://github.com/torvalds/linux/commit/09519ec3b19e4144b5f6e269c54fbb9c294a9fcb
         #[cfg(feature = "linux-6.3")]
         config3: 0,
-    };
+    });
 
-    raw_attr.set_disabled(1);
-    raw_attr.set_inherit(extra_config.inherit as _);
-    raw_attr.set_pinned(extra_config.pinned as _);
-    raw_attr.set_exclusive(extra_config.exclusive as _);
+    perf_event_attr.set_disabled(1);
+    perf_event_attr.set_inherit(extra_config.inherit as _);
+    perf_event_attr.set_pinned(extra_config.pinned as _);
+    perf_event_attr.set_exclusive(extra_config.exclusive as _);
 
-    raw_attr.set_exclude_user(1);
-    raw_attr.set_exclude_kernel(1);
-    raw_attr.set_exclude_hv(1);
-    raw_attr.set_exclude_idle(1);
+    perf_event_attr.set_exclude_user(1);
+    perf_event_attr.set_exclude_kernel(1);
+    perf_event_attr.set_exclude_hv(1);
+    perf_event_attr.set_exclude_idle(1);
 
-    raw_attr.set_mmap(0); // not use in counting mode
-    raw_attr.set_comm(0); // ditto
-    raw_attr.set_freq(0); // ditto
-    raw_attr.set_inherit_stat(extra_config.inherit_stat as _);
-    raw_attr.set_enable_on_exec(extra_config.enable_on_exec as _);
-    raw_attr.set_task(0); // not use in counting mode
-    raw_attr.set_watermark(0); // ditto
-    raw_attr.set_precise_ip(0); // ditto
-    raw_attr.set_mmap_data(0); // ditto
-    raw_attr.set_sample_id_all(0); // ditto
+    perf_event_attr.set_mmap(0); // not use in counting mode
+    perf_event_attr.set_comm(0); // ditto
+    perf_event_attr.set_freq(0); // ditto
+    perf_event_attr.set_inherit_stat(extra_config.inherit_stat as _);
+    perf_event_attr.set_enable_on_exec(extra_config.enable_on_exec as _);
+    perf_event_attr.set_task(0); // not use in counting mode
+    perf_event_attr.set_watermark(0); // ditto
+    perf_event_attr.set_precise_ip(0); // ditto
+    perf_event_attr.set_mmap_data(0); // ditto
+    perf_event_attr.set_sample_id_all(0); // ditto
 
-    raw_attr.set_exclude_host(1);
-    raw_attr.set_exclude_guest(1);
+    perf_event_attr.set_exclude_host(1);
+    perf_event_attr.set_exclude_guest(1);
 
-    raw_attr.set_exclude_callchain_kernel(1);
-    raw_attr.set_exclude_callchain_user(1);
+    perf_event_attr.set_exclude_callchain_kernel(1);
+    perf_event_attr.set_exclude_callchain_user(1);
 
     #[cfg(feature = "linux-3.12")]
-    raw_attr.set_mmap2(0); // not use in counting mode
+    perf_event_attr.set_mmap2(0); // not use in counting mode
     #[cfg(feature = "linux-3.16")]
-    raw_attr.set_comm_exec(0); // ditto
+    perf_event_attr.set_comm_exec(0); // ditto
     #[cfg(feature = "linux-4.1")]
-    raw_attr.set_use_clockid(0); // ditto
+    perf_event_attr.set_use_clockid(0); // ditto
     #[cfg(feature = "linux-4.3")]
-    raw_attr.set_context_switch(0); // ditto
+    perf_event_attr.set_context_switch(0); // ditto
 
     // The `write_backward` was first added to the Linux kernel in 4.7
     // the man documentation incorrectly says "since Linux 4.6"
     // See: https://github.com/torvalds/linux/commit/9ecda41acb971ebd07c8fb35faf24005c0baea12
     #[cfg(feature = "linux-4.7")]
-    raw_attr.set_write_backward(0); // ditto
+    perf_event_attr.set_write_backward(0); // ditto
 
     #[cfg(feature = "linux-4.12")]
-    raw_attr.set_namespaces(0); // ditto
+    perf_event_attr.set_namespaces(0); // ditto
     #[cfg(feature = "linux-5.1")]
-    raw_attr.set_ksymbol(0); // ditto
+    perf_event_attr.set_ksymbol(0); // ditto
     #[cfg(feature = "linux-5.1")]
-    raw_attr.set_bpf_event(0); // ditto
+    perf_event_attr.set_bpf_event(0); // ditto
     #[cfg(feature = "linux-5.4")]
-    raw_attr.set_aux_output(0); // ditto
+    perf_event_attr.set_aux_output(0); // ditto
     #[cfg(feature = "linux-5.7")]
-    raw_attr.set_cgroup(0); // ditto
+    perf_event_attr.set_cgroup(0); // ditto
     #[cfg(feature = "linux-5.9")]
-    raw_attr.set_text_poke(0); // ditto
+    perf_event_attr.set_text_poke(0); // ditto
     #[cfg(feature = "linux-5.12")]
-    raw_attr.set_build_id(0); // ditto
+    perf_event_attr.set_build_id(0); // ditto
     #[cfg(feature = "linux-5.13")]
-    raw_attr.set_inherit_thread(extra_config.inherit_thread as _);
+    perf_event_attr.set_inherit_thread(extra_config.inherit_thread as _);
     #[cfg(feature = "linux-5.13")]
-    raw_attr.set_remove_on_exec(extra_config.remove_on_exec as _);
+    perf_event_attr.set_remove_on_exec(extra_config.remove_on_exec as _);
     #[cfg(feature = "linux-5.13")]
-    raw_attr.set_sigtrap(0); // not use in counting mode
+    perf_event_attr.set_sigtrap(0); // not use in counting mode
 
-    event.enable_in_raw_attr(&mut raw_attr);
+    event.enable_in_raw_attr(&mut perf_event_attr);
 
     scopes
         .into_iter()
-        .for_each(|scope| scope.enable_in_raw_attr(&mut raw_attr));
+        .for_each(|scope| scope.enable_in_raw_attr(&mut perf_event_attr));
 
     let kprobe_func_or_uprobe_path = match event {
         #[cfg(feature = "linux-4.17")]
@@ -147,6 +147,6 @@ pub fn new<'t>(
 
     Config {
         kprobe_func_or_uprobe_path,
-        raw_attr,
+        perf_event_attr,
     }
 }

--- a/src/perf_event/counting/group/inner.rs
+++ b/src/perf_event/counting/group/inner.rs
@@ -1,5 +1,5 @@
 use crate::counting::{inner_stat, Counter, CounterGroupStat};
-use crate::perf_event::RawAttr;
+use crate::perf_event::PerfEventAttr;
 use crate::syscall::bindings::*;
 use crate::syscall::{ioctl_wrapped, perf_event_open_wrapped};
 use libc::pid_t;
@@ -25,9 +25,14 @@ impl Inner {
         self.members.get_mut(0)
     }
 
-    pub fn add_member(&mut self, pid: pid_t, cpu: i32, raw_attr: &RawAttr) -> io::Result<u64> {
+    pub fn add_member(
+        &mut self,
+        pid: pid_t,
+        cpu: i32,
+        perf_event_attr: &PerfEventAttr,
+    ) -> io::Result<u64> {
         let group_fd = self.leader().map(|it| it.file.as_raw_fd()).unwrap_or(-1);
-        let fd = unsafe { perf_event_open_wrapped(raw_attr, pid, cpu, group_fd, 0) }?;
+        let fd = unsafe { perf_event_open_wrapped(perf_event_attr, pid, cpu, group_fd, 0) }?;
         let member = Counter {
             file: unsafe { File::from_raw_fd(fd) },
         };

--- a/src/perf_event/event/scope.rs
+++ b/src/perf_event/event/scope.rs
@@ -1,4 +1,4 @@
-use crate::perf_event::RawAttr;
+use crate::perf_event::PerfEventAttr;
 use std::ops::Not;
 
 #[derive(PartialEq, Eq, Clone, Debug)]
@@ -32,15 +32,15 @@ impl EventScope {
             .collect()
     }
 
-    pub(crate) fn enable_in_raw_attr(&self, raw_attr: &mut RawAttr) {
+    pub(crate) fn enable_in_raw_attr(&self, perf_event_attr: &mut PerfEventAttr) {
         #[rustfmt::skip]
         match self {
-            Self::User   => raw_attr.set_exclude_user(0),
-            Self::Kernel => raw_attr.set_exclude_kernel(0),
-            Self::Hv     => raw_attr.set_exclude_hv(0),
-            Self::Idle   => raw_attr.set_exclude_idle(0),
-            Self::Host   => raw_attr.set_exclude_host(0),
-            Self::Guest  => raw_attr.set_exclude_guest(0),
+            Self::User   => perf_event_attr.set_exclude_user(0),
+            Self::Kernel => perf_event_attr.set_exclude_kernel(0),
+            Self::Hv     => perf_event_attr.set_exclude_hv(0),
+            Self::Idle   => perf_event_attr.set_exclude_idle(0),
+            Self::Host   => perf_event_attr.set_exclude_host(0),
+            Self::Guest  => perf_event_attr.set_exclude_guest(0),
         };
     }
 }

--- a/src/perf_event/mod.rs
+++ b/src/perf_event/mod.rs
@@ -7,4 +7,349 @@ pub mod tracing;
 use crate::syscall::bindings::perf_event_attr;
 pub use event::*;
 
-type RawAttr = perf_event_attr;
+pub type RawPerfEventAttr = perf_event_attr;
+
+#[derive(Debug, Clone)]
+pub struct PerfEventAttr(pub RawPerfEventAttr);
+
+impl std::ops::Deref for PerfEventAttr {
+    type Target = RawPerfEventAttr;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for PerfEventAttr {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl PerfEventAttr {
+    /// The `disabled` bit specifies whether the counter starts out `disabled` or `enabled`.
+    /// If `disabled`, the event can later be enabled by ioctl(2), prctl(2), or enable_on_exec.
+    ///
+    /// When  creating  an event group, typically the group leader is initialized with `disabled` set to 1 and any child events
+    /// are initialized with `disabled` set to 0.  Despite `disabled` being 0, the child events will not start until the group leader is enabled.
+    #[inline]
+    pub fn set_disabled(&mut self, val: u64) {
+        self.0.set_disabled(val)
+    }
+
+    /// The `inherit` bit specifies that this counter should count events of child tasks as well as the task specified.
+    /// This applies only to new children, not to any existing children at  the  time the counter is created (nor to any new children of existing children).
+    #[inline]
+    pub fn set_inherit(&mut self, val: u64) {
+        self.0.set_inherit(val)
+    }
+
+    /// The `pinned` bit specifies that the counter should always be on the CPU if at all possible.
+    /// It applies only to hardware counters and only to group leaders.  If a `pinned` counter cannot be
+    /// put onto the CPU (e.g., because there are not enough hardware counters or because of a conflict with some other event),
+    /// then the counter goes into an 'error' state, where reads return end-of-file (i.e., read(2) returns 0)
+    /// until the counter is subsequently enabled or disabled.
+    #[inline]
+    pub fn set_pinned(&mut self, val: u64) {
+        self.0.set_pinned(val)
+    }
+
+    /// The `exclusive` bit specifies that when this counter's group is on the CPU, it should be the only group using the CPU's counters.
+    /// In the future this may allow monitoring programs to support PMU features that need to run alone so that they do not disrupt other hardware counters.
+    ///
+    /// Note that many unexpected situations may prevent events with the `exclusive` bit set from ever running.
+    /// This includes any users running a system-wide measurement as well as any  kernel use
+    /// of the performance counters (including the commonly enabled NMI Watchdog Timer interface).
+    #[inline]
+    pub fn set_exclusive(&mut self, val: u64) {
+        self.0.set_exclusive(val)
+    }
+
+    /// If this bit is set, the count excludes events that happen in user space.
+    #[inline]
+    pub fn set_exclude_user(&mut self, val: u64) {
+        self.0.set_exclude_user(val)
+    }
+
+    /// If this bit is set, the count excludes events that happen in kernel space.
+    #[inline]
+    pub fn set_exclude_kernel(&mut self, val: u64) {
+        self.0.set_exclude_kernel(val)
+    }
+
+    /// If this bit is set, the count excludes events that happen in the hypervisor.
+    /// This is mainly for PMUs that have built-in support for handling this (such as POWER).
+    /// Extra support is needed for handling hypervisor measurements on most machines.
+    #[inline]
+    pub fn set_exclude_hv(&mut self, val: u64) {
+        self.0.set_exclude_hv(val)
+    }
+
+    /// If set, don't count when the CPU is running the idle task.
+    /// While you can currently enable this for any event type, it is ignored for all but software events.
+    #[inline]
+    pub fn set_exclude_idle(&mut self, val: u64) {
+        self.0.set_exclude_idle(val)
+    }
+
+    /// The `mmap` bit enables generation of PERF_RECORD_MMAP samples for every mmap(2) call that has PROT_EXEC set.
+    /// This allows tools to notice new executable code being mapped into a program (dy‐namic shared libraries for example)
+    /// so that addresses can be mapped back to the original code.
+    #[inline]
+    pub fn set_mmap(&mut self, val: u64) {
+        self.0.set_mmap(val)
+    }
+
+    /// The `comm` bit enables tracking of process command name as modified by the exec(2) and prctl(PR_SET_NAME) system calls as well as writing to /proc/self/comm.
+    /// If the comm_exec flag is also successfully set (possible since Linux 3.16),
+    /// then the misc flag PERF_RECORD_MISC_COMM_EXEC can be used to differentiate the exec(2) case from the others.
+    #[inline]
+    pub fn set_comm(&mut self, val: u64) {
+        self.0.set_comm(val)
+    }
+
+    /// If this bit is set, then `sample_frequency` not `sample_period` is used when setting up the sampling interval.
+    #[inline]
+    pub fn set_freq(&mut self, val: u64) {
+        self.0.set_freq(val)
+    }
+
+    /// This bit enables saving of event counts on context switch for inherited tasks. This is meaningful only if the `inherit` field is set.
+    #[inline]
+    pub fn set_inherit_stat(&mut self, val: u64) {
+        self.0.set_inherit_stat(val)
+    }
+
+    /// If this bit is set, a counter is automatically enabled after a call to exec(2).
+    #[inline]
+    pub fn set_enable_on_exec(&mut self, val: u64) {
+        self.0.set_enable_on_exec(val)
+    }
+
+    /// If this bit is set, then fork/exit notifications are included in the ring buffer.
+    #[inline]
+    pub fn set_task(&mut self, val: u64) {
+        self.0.set_task(val)
+    }
+
+    /// If set, have an overflow notification happen when we cross the `wakeup_watermark` boundary.
+    /// Otherwise, overflow notifications happen after `wakeup_events` samples.
+    #[inline]
+    pub fn set_watermark(&mut self, val: u64) {
+        self.0.set_watermark(val)
+    }
+
+    /// (since Linux 2.6.35)
+    /// This controls the amount of skid.  Skid is how many instructions execute between an event of interest happening
+    /// and the kernel being able to stop and record the event. Smaller skid is better and allows more accurate reporting of
+    /// which events correspond to which instructions, but hardware is often limited with how small this can be.
+    ///
+    /// The possible values of this field are the following:
+    ///     0  SAMPLE_IP can have arbitrary skid.
+    ///     1  SAMPLE_IP must have constant skid.
+    ///     2  SAMPLE_IP requested to have 0 skid.
+    ///     3  SAMPLE_IP must have 0 skid.  See also the description of PERF_RECORD_MISC_EXACT_IP.
+    #[inline]
+    pub fn set_precise_ip(&mut self, val: u64) {
+        self.0.set_precise_ip(val)
+    }
+
+    /// (since Linux 2.6.36)
+    /// This is the counterpart of the `mmap` field.  This enables generation of PERF_RECORD_MMAP samples
+    /// for mmap(2) calls that do not have PROT_EXEC set (for example data and SysV shared memory).
+    #[inline]
+    pub fn set_mmap_data(&mut self, val: u64) {
+        self.0.set_mmap_data(val)
+    }
+
+    /// (since Linux 2.6.38)
+    /// If set, then TID, TIME, ID, STREAM_ID, and CPU can additionally be included in non-PERF_RECORD_SAMPLEs if the corresponding sample_type is selected.
+    /// If PERF_SAMPLE_IDENTIFIER is specified, then an additional ID value is included as the last value to ease parsing the record stream.
+    /// This may lead to the id value appearing twice.
+    ///
+    /// The layout is described by this pseudo-structure:
+    /// ```C
+    ///     struct sample_id {
+    ///         { u32 pid, tid; }   /* if PERF_SAMPLE_TID set */
+    ///         { u64 time;     }   /* if PERF_SAMPLE_TIME set */
+    ///         { u64 id;       }   /* if PERF_SAMPLE_ID set */
+    ///         { u64 stream_id;}   /* if PERF_SAMPLE_STREAM_ID set  */
+    ///         { u32 cpu, res; }   /* if PERF_SAMPLE_CPU set */
+    ///         { u64 id;       }   /* if PERF_SAMPLE_IDENTIFIER set */
+    ///     };
+    /// ```
+    #[inline]
+    pub fn set_sample_id_all(&mut self, val: u64) {
+        self.0.set_sample_id_all(val)
+    }
+
+    /// (since Linux 3.2)
+    /// When conducting measurements that include processes running VM instances (i.e.,
+    /// have executed a KVM_RUN ioctl(2)), only measure events happening inside a guest instance.
+    /// This is only meaningful outside the guests; this setting does not change counts gathered inside of a guest.
+    /// Currently, this functionality is x86 only.
+    #[inline]
+    pub fn set_exclude_host(&mut self, val: u64) {
+        self.0.set_exclude_host(val)
+    }
+
+    /// (since Linux 3.2)
+    /// When conducting measurements that include processes running VM instances (i.e., have executed a KVM_RUN ioctl(2)),
+    /// do not measure events happening inside guest instances. This is only meaningful outside the guests; this setting does not
+    /// change counts gathered inside of a guest.Currently, this functionality is x86 only.
+    #[inline]
+    pub fn set_exclude_guest(&mut self, val: u64) {
+        self.0.set_exclude_guest(val)
+    }
+
+    /// (since Linux 3.7)
+    /// Do not include kernel callchains.
+    #[inline]
+    pub fn set_exclude_callchain_kernel(&mut self, val: u64) {
+        self.0.set_exclude_callchain_kernel(val)
+    }
+
+    /// (since Linux 3.7)
+    /// Do not include user callchains.
+    #[inline]
+    pub fn set_exclude_callchain_user(&mut self, val: u64) {
+        self.0.set_exclude_callchain_user(val)
+    }
+
+    /// (since Linux 3.16[Ref: man perf_event_open], feature selection from `linux-3.12`)
+    /// Generate an extended executable mmap record that contains enough additional information to uniquely identify shared mappings.
+    /// The `mmap` flag must also be set for this to work.
+    /// FIXME (Chengdong Li)
+    #[cfg(feature = "linux-3.12")]
+    #[inline]
+    pub fn set_mmap2(&mut self, val: u64) {
+        self.0.set_mmap2(val)
+    }
+
+    /// (since Linux 3.16)
+    /// This  is purely a feature-detection flag, it does not change kernel behavior.
+    /// If this flag can successfully be set, then, when `comm` is enabled, the PERF_RECORD_MISC_COMM_EXEC flag will be
+    /// set in the misc field of a `comm` record header if the rename event being reported was caused by a call to exec(2).
+    /// This allows tools to distinguish between the various types of process renaming.
+    #[cfg(feature = "linux-3.16")]
+    #[inline]
+    pub fn set_comm_exec(&mut self, val: u64) {
+        self.0.set_comm_exec(val)
+    }
+
+    /// (since Linux 4.1)
+    /// This allows selecting which internal Linux clock to use when generating timestamps via the `clockid` field.
+    /// This can make it easier to correlate perf sample times with timestamps generated by other tools.
+    #[cfg(feature = "linux-4.1")]
+    #[inline]
+    pub fn set_use_clockid(&mut self, val: u64) {
+        self.0.set_use_clockid(val)
+    }
+
+    /// (since Linux 4.3)
+    /// This enables the generation of PERF_RECORD_SWITCH records when a context switch occurs.
+    /// It also enables the generation of PERF_RECORD_SWITCH_CPU_WIDE records when sampling in CPU-wide mode.
+    /// This functionality is in addition to existing tracepoint and software events for measuring context switches.
+    /// The advantage of this method is that it will give full information even with strict perf_event_paranoid settings.
+    #[cfg(feature = "linux-4.3")]
+    #[inline]
+    pub fn set_context_switch(&mut self, val: u64) {
+        self.0.set_context_switch(val)
+    }
+
+    /// (since Linux 4.6[Ref: man perf_event_open], feature selection from `linux-4.7`)
+    /// This causes the ring buffer to be written from the end to the beginning.
+    /// This is to support reading from overwritable ring buffer.
+    ///
+    // The `write_backward` was first added to the Linux kernel in 4.7
+    // the man documentation incorrectly says "since Linux 4.6"
+    // See: https://github.com/torvalds/linux/commit/9ecda41acb971ebd07c8fb35faf24005c0baea12
+    #[cfg(feature = "linux-4.7")]
+    #[inline]
+    pub fn set_write_backward(&mut self, val: u64) {
+        self.0.set_write_backward(val)
+    }
+
+    /// (since Linux 4.6[Ref: man perf_event_open], feature selection from `linux-4.12`)
+    /// This enables the generation of PERF_RECORD_NAMESPACES records when a task enters a new namespace.
+    /// Each namespace has a combination of device and inode numbers.
+    #[cfg(feature = "linux-4.12")]
+    #[inline]
+    pub fn set_namespaces(&mut self, val: u64) {
+        self.0.set_namespaces(val)
+    }
+
+    /// (since Linux 5.0[Ref: man perf_event_open], feature selection from `linux-5.1`)
+    /// This enables the generation of PERF_RECORD_KSYMBOL records when new kernel symbols are registered or unregistered.
+    /// This is analyzing dynamic kernel functions like eBPF.
+    #[cfg(feature = "linux-5.1")]
+    #[inline]
+    pub fn set_ksymbol(&mut self, val: u64) {
+        self.0.set_ksymbol(val)
+    }
+
+    /// (since Linux 5.0[Ref: man perf_event_open], feature selection from `linux-5.1`)
+    /// This enables the generation of PERF_RECORD_BPF_EVENT records when an eBPF program is loaded or unloaded.
+    #[cfg(feature = "linux-5.1")]
+    #[inline]
+    pub fn set_bpf_event(&mut self, val: u64) {
+        self.0.set_bpf_event(val)
+    }
+
+    /// (since Linux 5.4)
+    /// This allows normal (non-AUX) events to generate data for AUX events if the hardware supports it.
+    #[cfg(feature = "linux-5.4")]
+    #[inline]
+    pub fn set_aux_output(&mut self, val: u64) {
+        self.0.set_aux_output(val)
+    }
+
+    /// (since Linux 5.7)
+    /// This enables the generation of PERF_RECORD_CGROUP records when a new cgroup is created (and activated).
+    #[cfg(feature = "linux-5.7")]
+    #[inline]
+    pub fn set_cgroup(&mut self, val: u64) {
+        self.0.set_cgroup(val)
+    }
+
+    /// (since Linux 5.8[Ref: man perf_event_open], feature selection from `linux-5.9`)
+    /// This enables the generation of PERF_RECORD_TEXT_POKE records when there's a changes to the kernel text (i.e., self-modifying code).
+    #[cfg(feature = "linux-5.9")]
+    #[inline]
+    pub fn set_text_poke(&mut self, val: u64) {
+        self.0.set_text_poke(val)
+    }
+
+    /// (since Linux 5.12)
+    /// This changes the contents in the PERF_RECORD_MMAP2 to have a build-id instead of device and inode numbers.
+    #[cfg(feature = "linux-5.12")]
+    #[inline]
+    pub fn set_build_id(&mut self, val: u64) {
+        self.0.set_build_id(val)
+    }
+
+    /// (since Linux 5.13)
+    /// This disables the inheritance of the event to a child process.
+    /// Only new threads in the same process (which is cloned with CLONE_THREAD) will inherit the event.
+    #[cfg(feature = "linux-5.13")]
+    #[inline]
+    pub fn set_inherit_thread(&mut self, val: u64) {
+        self.0.set_inherit_thread(val)
+    }
+
+    /// (since Linux 5.13)
+    /// This closes the event when it starts a new process image by execve(2).
+    #[cfg(feature = "linux-5.13")]
+    #[inline]
+    pub fn set_remove_on_exec(&mut self, val: u64) {
+        self.0.set_remove_on_exec(val)
+    }
+
+    /// (since Linux 5.13)
+    /// This enables synchronous signal delivery of SIGTRAP on event overflow.
+    #[cfg(feature = "linux-5.13")]
+    #[inline]
+    pub fn set_sigtrap(&mut self, val: u64) {
+        self.0.set_sigtrap(val)
+    }
+}

--- a/src/perf_event/sampling/config/extra_record.rs
+++ b/src/perf_event/sampling/config/extra_record.rs
@@ -1,4 +1,4 @@
-use crate::perf_event::RawAttr;
+use crate::perf_event::PerfEventAttr;
 use std::ops::Not;
 
 #[derive(PartialEq, Eq, Clone, Debug)]
@@ -75,25 +75,25 @@ impl ExtraRecord {
             .collect()
     }
 
-    pub(crate) fn enable_in_raw_attr(&self, raw_attr: &mut RawAttr) {
+    pub(crate) fn enable_in_raw_attr(&self, perf_event_attr: &mut PerfEventAttr) {
         #[rustfmt::skip]
         match self {
-            Self::Mmap          => raw_attr.set_mmap(1),
+            Self::Mmap          => perf_event_attr.set_mmap(1),
             #[cfg(feature = "linux-3.12")]
-            Self::Mmap2         => raw_attr.set_mmap2(1),
+            Self::Mmap2         => perf_event_attr.set_mmap2(1),
             #[cfg(feature = "linux-4.3")]
-            Self::ContextSwitch => raw_attr.set_context_switch(1),
+            Self::ContextSwitch => perf_event_attr.set_context_switch(1),
             #[cfg(feature = "linux-4.12")]
-            Self::Namespaces    => raw_attr.set_namespaces(1),
+            Self::Namespaces    => perf_event_attr.set_namespaces(1),
             #[cfg(feature = "linux-5.1")]
-            Self::Ksymbol       => raw_attr.set_ksymbol(1),
+            Self::Ksymbol       => perf_event_attr.set_ksymbol(1),
             #[cfg(feature = "linux-5.1")]
-            Self::BpfEvent      => raw_attr.set_bpf_event(1),
+            Self::BpfEvent      => perf_event_attr.set_bpf_event(1),
             #[cfg(feature = "linux-5.7")]
-            Self::Cgroup        => raw_attr.set_cgroup(1),
+            Self::Cgroup        => perf_event_attr.set_cgroup(1),
             #[cfg(feature = "linux-5.9")]
-            Self::TextPoke      => raw_attr.set_text_poke(1),
-            Self::ForkAndExit   => raw_attr.set_task(1),
+            Self::TextPoke      => perf_event_attr.set_text_poke(1),
+            Self::ForkAndExit   => perf_event_attr.set_task(1),
         };
     }
 }

--- a/src/perf_event/sampling/config/mod.rs
+++ b/src/perf_event/sampling/config/mod.rs
@@ -3,7 +3,7 @@ mod extra_record;
 mod new;
 mod sample_record_fields;
 
-use crate::perf_event::RawAttr;
+use crate::perf_event::PerfEventAttr;
 use crate::{Event, EventScope};
 use std::ffi::CString;
 use std::fmt::Debug;
@@ -24,7 +24,7 @@ pub struct Config {
     // This will keep the ptr of `kprobe_func` or `uprobe_path` valid if present.
     #[allow(dead_code)]
     kprobe_func_or_uprobe_path: Option<Rc<CString>>,
-    raw_attr: RawAttr,
+    perf_event_attr: PerfEventAttr,
 }
 
 impl Config {
@@ -45,22 +45,22 @@ impl Config {
         new::new(event, scopes, overflow_by, extra_config)
     }
 
-    /// Construct from a raw `perf_event_attr` struct.
+    /// Construct from a `PerfEventAttr` struct.
     /// # Safety
-    /// The `raw_attr` argument must be a properly initialized
-    /// `perf_event_attr` struct for counting mode.
-    pub const unsafe fn from_raw(raw_attr: RawAttr) -> Self {
+    /// The `perf_event_attr` argument must be properly initialized from
+    /// `PerfEventAttr` struct for counting mode.
+    pub const unsafe fn from_raw(perf_event_attr: PerfEventAttr) -> Self {
         Self {
             kprobe_func_or_uprobe_path: None,
-            raw_attr,
+            perf_event_attr,
         }
     }
 
-    pub fn into_raw(self) -> RawAttr {
-        self.raw_attr
+    pub fn into_raw(self) -> PerfEventAttr {
+        self.perf_event_attr
     }
 
-    pub const fn as_raw(&self) -> &RawAttr {
-        &self.raw_attr
+    pub const fn as_raw(&self) -> &PerfEventAttr {
+        &self.perf_event_attr
     }
 }

--- a/src/perf_event/sampling/config/new.rs
+++ b/src/perf_event/sampling/config/new.rs
@@ -1,11 +1,11 @@
-use crate::perf_event::RawAttr;
+use crate::perf_event::PerfEventAttr;
 #[cfg(feature = "linux-4.1")]
 use crate::sampling::ClockId;
 use crate::sampling::{Config, ExtraConfig, OverflowBy, SampleIpSkid, Wakeup};
 use crate::syscall::bindings::*;
 #[cfg(feature = "linux-4.17")]
 use crate::{DynamicPmuEvent, KprobeConfig, UprobeConfig};
-use crate::{Event, EventScope};
+use crate::{Event, EventScope, RawPerfEventAttr};
 #[cfg(feature = "linux-4.1")]
 use libc::{CLOCK_BOOTTIME, CLOCK_MONOTONIC, CLOCK_MONOTONIC_RAW, CLOCK_REALTIME, CLOCK_TAI};
 use std::mem::size_of;
@@ -20,9 +20,9 @@ pub fn new<'t>(
 ) -> Config {
     let sample_record_fields = &extra_config.sample_record_fields;
 
-    let mut raw_attr = RawAttr {
+    let mut perf_event_attr = PerfEventAttr(RawPerfEventAttr {
         type_: 0,
-        size: size_of::<RawAttr>() as _,
+        size: size_of::<RawPerfEventAttr>() as _,
         config: 0,
         __bindgen_anon_1: match overflow_by {
             OverflowBy::Freq(f) => perf_event_attr__bindgen_ty_1 { sample_freq: *f },
@@ -46,7 +46,7 @@ pub fn new<'t>(
             val as _
         },
         _bitfield_align_1: [],
-        // set later via raw_attr.set_...
+        // set later via perf_event_attr.set_...
         _bitfield_1: __BindgenBitfieldUnit::new([0u8; 8usize]),
         __bindgen_anon_2: match &extra_config.wakeup {
             Wakeup::Events(val) => perf_event_attr__bindgen_ty_2 {
@@ -91,9 +91,9 @@ pub fn new<'t>(
         // TODO: https://github.com/torvalds/linux/commit/09519ec3b19e4144b5f6e269c54fbb9c294a9fcb
         #[cfg(feature = "linux-6.3")]
         config3: 0,
-    };
+    });
 
-    raw_attr.set_disabled(1);
+    perf_event_attr.set_disabled(1);
 
     /*
     Line 6402 of kernel/events/core.c:
@@ -101,91 +101,91 @@ pub fn new<'t>(
     create a performance issue due to all children writing to the
     same rb.
     */
-    raw_attr.set_inherit(extra_config.inherit as _);
-    raw_attr.set_pinned(extra_config.pinned as _);
-    raw_attr.set_exclusive(extra_config.exclusive as _);
+    perf_event_attr.set_inherit(extra_config.inherit as _);
+    perf_event_attr.set_pinned(extra_config.pinned as _);
+    perf_event_attr.set_exclusive(extra_config.exclusive as _);
 
-    raw_attr.set_exclude_user(1);
-    raw_attr.set_exclude_kernel(1);
-    raw_attr.set_exclude_hv(1);
-    raw_attr.set_exclude_idle(1);
+    perf_event_attr.set_exclude_user(1);
+    perf_event_attr.set_exclude_kernel(1);
+    perf_event_attr.set_exclude_hv(1);
+    perf_event_attr.set_exclude_idle(1);
 
-    raw_attr.set_mmap(0);
-    raw_attr.set_comm(extra_config.comm as _);
-    raw_attr.set_freq(match overflow_by {
+    perf_event_attr.set_mmap(0);
+    perf_event_attr.set_comm(extra_config.comm as _);
+    perf_event_attr.set_freq(match overflow_by {
         OverflowBy::Freq(_) => 1,
         OverflowBy::Period(_) => 0,
     });
-    raw_attr.set_inherit_stat(extra_config.inherit_stat as _); // `inherit_stat` requires `inherit` to be enabled
-    raw_attr.set_enable_on_exec(extra_config.enable_on_exec as _);
-    raw_attr.set_task(0);
-    raw_attr.set_watermark(match extra_config.wakeup {
+    perf_event_attr.set_inherit_stat(extra_config.inherit_stat as _); // `inherit_stat` requires `inherit` to be enabled
+    perf_event_attr.set_enable_on_exec(extra_config.enable_on_exec as _);
+    perf_event_attr.set_task(0);
+    perf_event_attr.set_watermark(match extra_config.wakeup {
         Wakeup::Watermark(_) => 1,
         Wakeup::Events(_) => 0,
     });
-    raw_attr.set_precise_ip(match extra_config.precise_ip {
+    perf_event_attr.set_precise_ip(match extra_config.precise_ip {
         SampleIpSkid::Arbitrary => 0,
         SampleIpSkid::Constant => 1,
         SampleIpSkid::TryZero => 2,
         SampleIpSkid::Zero => 3,
     });
-    raw_attr.set_mmap_data(extra_config.mmap_data as _);
+    perf_event_attr.set_mmap_data(extra_config.mmap_data as _);
 
     if extra_config.extra_record_with_sample_id && extra_config.extra_record_types.is_empty().not()
     {
-        raw_attr.set_sample_id_all(1);
+        perf_event_attr.set_sample_id_all(1);
     } else {
-        raw_attr.set_sample_id_all(0);
+        perf_event_attr.set_sample_id_all(0);
     }
 
-    raw_attr.set_exclude_host(1);
-    raw_attr.set_exclude_guest(1);
+    perf_event_attr.set_exclude_host(1);
+    perf_event_attr.set_exclude_guest(1);
 
-    raw_attr.set_exclude_callchain_kernel(extra_config.include_callchain_kernel.not() as _);
-    raw_attr.set_exclude_callchain_user(extra_config.include_callchain_user.not() as _);
+    perf_event_attr.set_exclude_callchain_kernel(extra_config.include_callchain_kernel.not() as _);
+    perf_event_attr.set_exclude_callchain_user(extra_config.include_callchain_user.not() as _);
 
     #[cfg(feature = "linux-3.12")]
-    raw_attr.set_mmap2(0);
+    perf_event_attr.set_mmap2(0);
     #[cfg(feature = "linux-3.16")]
-    raw_attr.set_comm_exec(extra_config.comm_exec as _);
+    perf_event_attr.set_comm_exec(extra_config.comm_exec as _);
     #[cfg(feature = "linux-4.1")]
-    raw_attr.set_use_clockid(extra_config.clockid.is_some() as _);
+    perf_event_attr.set_use_clockid(extra_config.clockid.is_some() as _);
     #[cfg(feature = "linux-4.3")]
-    raw_attr.set_context_switch(0);
+    perf_event_attr.set_context_switch(0);
     #[cfg(feature = "linux-4.7")]
-    raw_attr.set_write_backward(0);
+    perf_event_attr.set_write_backward(0);
     #[cfg(feature = "linux-4.12")]
-    raw_attr.set_namespaces(0);
+    perf_event_attr.set_namespaces(0);
     #[cfg(feature = "linux-5.1")]
-    raw_attr.set_ksymbol(0);
+    perf_event_attr.set_ksymbol(0);
     #[cfg(feature = "linux-5.1")]
-    raw_attr.set_bpf_event(0);
+    perf_event_attr.set_bpf_event(0);
     #[cfg(feature = "linux-5.4")]
-    //raw_attr.set_aux_output(extra_config.aux_output as _);
-    raw_attr.set_aux_output(0);
+    //perf_event_attr.set_aux_output(extra_config.aux_output as _);
+    perf_event_attr.set_aux_output(0);
     #[cfg(feature = "linux-5.7")]
-    raw_attr.set_cgroup(0);
+    perf_event_attr.set_cgroup(0);
     #[cfg(feature = "linux-5.9")]
-    raw_attr.set_text_poke(0);
+    perf_event_attr.set_text_poke(0);
     #[cfg(feature = "linux-5.12")]
-    raw_attr.set_build_id(extra_config.build_id as _);
+    perf_event_attr.set_build_id(extra_config.build_id as _);
     #[cfg(feature = "linux-5.13")]
-    raw_attr.set_inherit_thread(extra_config.inherit_thread as _);
+    perf_event_attr.set_inherit_thread(extra_config.inherit_thread as _);
     #[cfg(feature = "linux-5.13")]
-    raw_attr.set_remove_on_exec(extra_config.remove_on_exec as _);
+    perf_event_attr.set_remove_on_exec(extra_config.remove_on_exec as _);
     #[cfg(feature = "linux-5.13")]
-    raw_attr.set_sigtrap(extra_config.sigtrap.is_some() as _);
+    perf_event_attr.set_sigtrap(extra_config.sigtrap.is_some() as _);
 
-    event.enable_in_raw_attr(&mut raw_attr);
+    event.enable_in_raw_attr(&mut perf_event_attr);
 
     scopes
         .into_iter()
-        .for_each(|scope| scope.enable_in_raw_attr(&mut raw_attr));
+        .for_each(|scope| scope.enable_in_raw_attr(&mut perf_event_attr));
 
     extra_config
         .extra_record_types
         .iter()
-        .for_each(|it| it.enable_in_raw_attr(&mut raw_attr));
+        .for_each(|it| it.enable_in_raw_attr(&mut perf_event_attr));
 
     let kprobe_func_or_uprobe_path = match event {
         #[cfg(feature = "linux-4.17")]
@@ -203,6 +203,6 @@ pub fn new<'t>(
 
     Config {
         kprobe_func_or_uprobe_path,
-        raw_attr,
+        perf_event_attr,
     }
 }

--- a/src/perf_event/sampling/single/mod.rs
+++ b/src/perf_event/sampling/single/mod.rs
@@ -58,9 +58,9 @@ impl Sampler {
             (-1, -1) => return Err(Error::InvalidProcessCpu),
             (pid, cpu) => (pid, cpu),
         };
-        let raw_attr = cfg.as_raw();
+        let perf_event_attr = cfg.as_raw();
 
-        let fd = unsafe { perf_event_open_wrapped(raw_attr, pid, cpu, -1, 0) }
+        let fd = unsafe { perf_event_open_wrapped(perf_event_attr, pid, cpu, -1, 0) }
             .map_err(Error::SyscallFailed)?;
         let file = unsafe { File::from_raw_fd(fd) };
 
@@ -78,11 +78,11 @@ impl Sampler {
             file,
             data_size: ((mmap_pages - 1) * page_size) as _,
             data_offset: page_size as _,
-            sample_type: raw_attr.sample_type,
-            sample_id_all: raw_attr.sample_id_all() > 0,
-            regs_user_len: raw_attr.sample_regs_user.count_ones() as _,
+            sample_type: perf_event_attr.sample_type,
+            sample_id_all: perf_event_attr.sample_id_all() > 0,
+            regs_user_len: perf_event_attr.sample_regs_user.count_ones() as _,
             #[cfg(feature = "linux-3.19")]
-            regs_intr_len: raw_attr.sample_regs_intr.count_ones() as _,
+            regs_intr_len: perf_event_attr.sample_regs_intr.count_ones() as _,
         }
         .wrap_ok()
     }

--- a/src/perf_event/tracing/config/mod.rs
+++ b/src/perf_event/tracing/config/mod.rs
@@ -1,6 +1,6 @@
 mod new;
 
-use crate::perf_event::RawAttr;
+use crate::perf_event::PerfEventAttr;
 use crate::{Event, EventScope};
 use std::ffi::CString;
 use std::rc::Rc;
@@ -12,7 +12,7 @@ pub struct Config {
     // This will keep the ptr of `kprobe_func` or `uprobe_path` valid if present.
     #[allow(dead_code)]
     kprobe_func_or_uprobe_path: Option<Rc<CString>>,
-    raw_attr: RawAttr,
+    perf_event_attr: PerfEventAttr,
 }
 
 impl Config {
@@ -28,22 +28,22 @@ impl Config {
         new::new(event, scopes, extra_config)
     }
 
-    /// Construct from a raw `perf_event_attr` struct.
+    /// Construct from a `PerfEventAttr` struct.
     /// # Safety
-    /// The `raw_attr` argument must be a properly initialized
-    /// `perf_event_attr` struct for counting mode.
-    pub const unsafe fn from_raw(raw_attr: RawAttr) -> Self {
+    /// The `perf_event_attr` argument must be properly initialized from
+    /// `PerfEventAttr` struct for counting mode.
+    pub const unsafe fn from_raw(perf_event_attr: PerfEventAttr) -> Self {
         Self {
             kprobe_func_or_uprobe_path: None,
-            raw_attr,
+            perf_event_attr,
         }
     }
 
-    pub fn into_raw(self) -> RawAttr {
-        self.raw_attr
+    pub fn into_raw(self) -> PerfEventAttr {
+        self.perf_event_attr
     }
 
-    pub const fn as_raw(&self) -> &RawAttr {
-        &self.raw_attr
+    pub const fn as_raw(&self) -> &PerfEventAttr {
+        &self.perf_event_attr
     }
 }

--- a/src/perf_event/tracing/tracer/mod.rs
+++ b/src/perf_event/tracing/tracer/mod.rs
@@ -41,8 +41,8 @@ impl Tracer {
             (-1, -1) => return Err(Error::InvalidProcessCpu),
             (pid, cpu) => (pid, cpu),
         };
-        let raw_attr = cfg.as_raw();
-        let fd = unsafe { perf_event_open_wrapped(raw_attr, pid, cpu, -1, 0) }
+        let perf_event_attr = cfg.as_raw();
+        let fd = unsafe { perf_event_open_wrapped(perf_event_attr, pid, cpu, -1, 0) }
             .map_err(Error::SyscallFailed)?;
         let file = unsafe { File::from_raw_fd(fd) };
 
@@ -60,11 +60,11 @@ impl Tracer {
             file,
             data_size: ((mmap_pages - 1) * page_size) as _,
             data_offset: page_size as _,
-            sample_type: raw_attr.sample_type,
-            sample_id_all: raw_attr.sample_id_all() > 0,
-            regs_user_len: raw_attr.sample_regs_user.count_ones() as _,
+            sample_type: perf_event_attr.sample_type,
+            sample_id_all: perf_event_attr.sample_id_all() > 0,
+            regs_user_len: perf_event_attr.sample_regs_user.count_ones() as _,
             #[cfg(feature = "linux-3.19")]
-            regs_intr_len: raw_attr.sample_regs_intr.count_ones() as _,
+            regs_intr_len: perf_event_attr.sample_regs_intr.count_ones() as _,
         };
 
         Ok(Self { sampler })


### PR DESCRIPTION
- After wrapped to a new Rust struct, it allows to define some wrap functions with appropriate documentation, thus functions callers know how to use them correctly.
- Also renamed type `RawAttr` to `RawPerfEventAttr` to make it more clear.